### PR TITLE
Fix typo

### DIFF
--- a/src/projects.html
+++ b/src/projects.html
@@ -142,7 +142,7 @@ title: Projects & Members of the Open Home Foundation
               standalone apps for Android and iOS. It is a feature-rich project,
               with a modern user interface, over-the-air updates, and support
               for addressable RGBW strips. The Open Home Foundation owns ESP Web
-              Tools, with powers the WLED web installer, making the project more
+              Tools, which powers the WLED web installer, making the project more
               accessible for more people.
             </p>
             <a


### PR DESCRIPTION
From:
The Open Home Foundation owns ESP Web Tools, **with** powers the WLED web installer, making the project more accessible for more people.

To:
The Open Home Foundation owns ESP Web Tools, **which** powers the WLED web installer, making the project more accessible for more people.