### PR TITLE
Add 2026 Open Home Foundation Budget document link

### DIFF
--- a/_data/documents.yml
+++ b/_data/documents.yml
@@ -41,3 +41,5 @@ sections:
     documents:
       - title: "2025 Open Home Foundation Budget"
         link: "https://drive.google.com/file/d/1IAqzddWX7TNmQokH9yZ5ySTzaoYR41Hm/view"
+      - title: "2026 Open Home Foundation Budget"
+        link: "https://docs.google.com/document/d/1Z3iFiFIc3uIeGkmSaEHGxTjQxmhyPZl_naHVZ_X7GHQ/edit?usp=sharing"


### PR DESCRIPTION
## Summary
Added a new document link for the 2026 Open Home Foundation Budget to the documents data file.

## Changes
- Added entry for "2026 Open Home Foundation Budget" with link to Google Docs document in the documents configuration file

## Details
This update adds the upcoming year's budget document to the publicly accessible documents list, following the same structure as the existing 2025 budget entry.

https://claude.ai/code/session_01M7j6sjwbJ1iCXq5sCeXeZQ