### PR TITLE
Ship harfbuzz wasm in the asset-generator function

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -15,7 +15,12 @@ export default defineConfig({
   // The site is fully prerendered except the routes that opt out with
   // `export const prerender = false` (the asset-generator image endpoint),
   // which the adapter runs as a Netlify function.
-  adapter: netlify(),
+  adapter: netlify({
+    // satori shapes text with harfbuzzjs, which reads its wasm from disk at
+    // runtime; the function bundler's trace only picks up the .js, so ship
+    // the wasm explicitly or every render crashes with ENOENT hb.wasm.
+    includeFiles: ["node_modules/harfbuzzjs/hb.wasm"],
+  }),
   server: {
     // Astro's dev server only binds to localhost by default. In a
     // devcontainer/Codespace, forwarded ports can't reach a


### PR DESCRIPTION
Fixes the runtime crash in the deployed asset-generator endpoint from [PR #120](https://github.com/OpenHomeFoundation/openhomefoundation.org/pull/120):

```
ENOENT: no such file or directory, open '/var/task/node_modules/harfbuzzjs/hb.wasm'
```

**Cause:** satori shapes text with `harfbuzzjs`, which loads its `hb.wasm` from disk (next to `hb.js`) at runtime. The Netlify adapter's file trace follows imports, so it shipped `hb.js` but not the wasm binary it reads with `fs.readFileSync`. Dev was unaffected because the full `node_modules` is on disk there — which is why this only surfaced on the deployed function.

**Fix:** one-liner — the adapter's `includeFiles` option adds `node_modules/harfbuzzjs/hb.wasm` to the function bundle, landing at exactly the path `hb.js` resolves (`/var/task/node_modules/harfbuzzjs/hb.wasm`).

**Verified:** `npm run build` now produces `.netlify/v1/functions/ssr/node_modules/harfbuzzjs/hb.wasm` (382 KB) in the function output; before the change that directory contained only the `.js` files, matching the production error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y2EpKK155ygmDZmLD6EcFc

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y2EpKK155ygmDZmLD6EcFc)_